### PR TITLE
fix: Lost reference after connection when scan is started

### DIFF
--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -175,7 +175,15 @@ class BleManager extends ReactContextBaseJavaModule {
             if (getCurrentActivity() == null)
                 callback.invoke("Current activity not available");
             else
-                getCurrentActivity().startActivityForResult(intentEnable, ENABLE_REQUEST);
+                {
+                    try{
+                        getCurrentActivity().startActivityForResult(intentEnable, ENABLE_REQUEST);
+                    }catch(Exception e){
+                        callback.invoke("Current activity not available");
+                    }
+                    
+                }
+                
         } else
             callback.invoke();
     }

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -175,15 +175,7 @@ class BleManager extends ReactContextBaseJavaModule {
             if (getCurrentActivity() == null)
                 callback.invoke("Current activity not available");
             else
-                {
-                    try{
-                        getCurrentActivity().startActivityForResult(intentEnable, ENABLE_REQUEST);
-                    }catch(Exception e){
-                        callback.invoke("Current activity not available");
-                    }
-                    
-                }
-                
+                getCurrentActivity().startActivityForResult(intentEnable, ENABLE_REQUEST);
         } else
             callback.invoke();
     }
@@ -289,25 +281,31 @@ class BleManager extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void connect(String peripheralUUID, ReadableMap options, Callback callback) {
-        Log.d(LOG_TAG, "Connect to: " + peripheralUUID);
+        synchronized (peripherals) {
+            Log.d(LOG_TAG, "Connect to: " + peripheralUUID);
 
-        Peripheral peripheral = retrieveOrCreatePeripheral(peripheralUUID);
-        if (peripheral == null) {
-            callback.invoke("Invalid peripheral uuid");
-            return;
+            Peripheral peripheral = retrieveOrCreatePeripheral(peripheralUUID);
+            if (peripheral == null) {
+                callback.invoke("Invalid peripheral uuid");
+                return;
+            }
+            Log.d(LOG_TAG, "Connecting to peripheral: " + peripheral.toString());
+            peripheral.connect(callback, getCurrentActivity(), options);
         }
-        peripheral.connect(callback, getCurrentActivity(), options);
     }
 
     @ReactMethod
     public void disconnect(String peripheralUUID, boolean force, Callback callback) {
-        Log.d(LOG_TAG, "Disconnect from: " + peripheralUUID);
+        synchronized (peripherals) {
+            Log.d(LOG_TAG, "Disconnect from: " + peripheralUUID);
 
-        Peripheral peripheral = peripherals.get(peripheralUUID);
-        if (peripheral != null) {
-            peripheral.disconnect(callback, force);
-        } else
-            callback.invoke("Peripheral not found");
+            Peripheral peripheral = peripherals.get(peripheralUUID);
+            if (peripheral != null) {
+                Log.d(LOG_TAG, "Disconnecting from peripheral: " + peripheral.toString());
+                peripheral.disconnect(callback, force);
+            } else
+                callback.invoke("Peripheral not found");
+        }
     }
 
     @ReactMethod
@@ -335,6 +333,7 @@ class BleManager extends ReactContextBaseJavaModule {
         }
         Peripheral peripheral = peripherals.get(deviceUUID);
         if (peripheral != null) {
+            Log.d(LOG_TAG, "Registering notify: " + peripheral.toString());
             peripheral.registerNotify(UUIDHelper.uuidFromString(serviceUUID),
                     UUIDHelper.uuidFromString(characteristicUUID), 1, callback);
         } else
@@ -769,22 +768,20 @@ class BleManager extends ReactContextBaseJavaModule {
     }
 
 
-    private Peripheral retrieveOrCreatePeripheral(String peripheralUUID) {
+    private synchronized Peripheral retrieveOrCreatePeripheral(String peripheralUUID) {
         Peripheral peripheral = peripherals.get(peripheralUUID);
         if (peripheral == null) {
-            synchronized (peripherals) {
-                if (peripheralUUID != null) {
-                    peripheralUUID = peripheralUUID.toUpperCase();
+            if (peripheralUUID != null) {
+                peripheralUUID = peripheralUUID.toUpperCase();
+            }
+            if (BluetoothAdapter.checkBluetoothAddress(peripheralUUID)) {
+                BluetoothDevice device = bluetoothAdapter.getRemoteDevice(peripheralUUID);
+                if (Build.VERSION.SDK_INT >= LOLLIPOP && !forceLegacy) {
+                    peripheral = new DefaultPeripheral(device, reactContext);
+                } else {
+                    peripheral = new Peripheral(device, reactContext);
                 }
-                if (BluetoothAdapter.checkBluetoothAddress(peripheralUUID)) {
-                    BluetoothDevice device = bluetoothAdapter.getRemoteDevice(peripheralUUID);
-                    if (Build.VERSION.SDK_INT >= LOLLIPOP && !forceLegacy) {
-                        peripheral = new DefaultPeripheral(device, reactContext);
-                    } else {
-                        peripheral = new Peripheral(device, reactContext);
-                    }
-                    peripherals.put(peripheralUUID, peripheral);
-                }
+                peripherals.put(peripheralUUID, peripheral);
             }
         }
         return peripheral;

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -109,11 +109,13 @@ public class Peripheral extends BluetoothGattCallback {
     }
 
     public void connect(final Callback callback, Activity activity, ReadableMap options) {
+        if (!connected) {
+            this.connecting = true;
+        }
         mainHandler.post(() -> {
             if (!connected) {
                 BluetoothDevice device = getDevice();
                 this.connectCallbacks.addLast(callback);
-                this.connecting = true;
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     Log.d(BleManager.LOG_TAG, " Is Or Greater than M $mBluetoothDevice");
                     boolean autoconnect = false;


### PR DESCRIPTION
If starting a scan simultaneously with a connection, the peripheral instance may be removed during the connection process. Depending on the timing, the peripheral can be either missing or replaced with a new instance when trying to use the device. If the instance is replaced, it has a null GATT instance. Thus, any calls using the GATT will fail. This fix guards the peripherals list during the connection and sets the "connecting" state of the peripheral in the same thread the connec function was called. Previously the state was set "late" in the main handler. This should guarantee that the peripheral instance is not removed during the connection process (after calling connect).